### PR TITLE
expose a hashable reader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["checksums", "checksum", "directory", "verification", "hash"]
 categories = ["authentication", "filesystem"]
 license = "MIT"
 # Remember to also update in appveyor.yml
-version = "0.6.0"
+version = "0.6.1"
 # Remember to also update in checksums.md
 authors = ["nabijaczleweli <nabijaczleweli@gmail.com>", "Zachary Dremann <dremann@gmail.com>"]
 exclude = ["*.enc"]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.6.0-{build}
+version: 0.6.1-{build}
 
 branches:
   except:
@@ -24,8 +24,8 @@ build: off
 build_script:
   - git submodule update --init --recursive
   - cargo build --verbose --release
-  - cp target\release\checksums.exe checksums-v0.6.0.exe
-  - strip --strip-all --remove-section=.comment --remove-section=.note checksums-v0.6.0.exe
+  - cp target\release\checksums.exe checksums-v0.6.1.exe
+  - strip --strip-all --remove-section=.comment --remove-section=.note checksums-v0.6.1.exe
 
 test: off
 test_script:
@@ -33,11 +33,11 @@ test_script:
   - target\release\checksums -cr --ignore target --ignore .git && cat checksums.hash
 
 artifacts:
-  - path: checksums-v0.6.0.exe
+  - path: checksums-v0.6.1.exe
 
 deploy:
   provider: GitHub
-  artifact: checksums-v0.6.0.exe
+  artifact: checksums-v0.6.1.exe
   auth_token:
     secure: zc/M0k0pSOFA3H9GhgTOFhYmOj6M88rfqwfjDhvhlzz/oa8P9JL+7XR4LmDHajJp
   on:

--- a/src/hashing/mod.rs
+++ b/src/hashing/mod.rs
@@ -39,6 +39,7 @@ macro_rules! hash_func_write {
 use super::Algorithm;
 use std::path::Path;
 use std::fmt::Write;
+use std::io::Read;
 use std::fs::File;
 
 mod md5;
@@ -55,29 +56,35 @@ mod sha1_2256_2224_2384_2512;
 
 
 /// Hash the specified file using the specified hashing algorithm.
+pub fn hash_reader<R: Read>(data: &mut R, algo: Algorithm) -> String {
+    match algo {
+        Algorithm::SHA1 => sha1_2256_2224_2384_2512::sha1::hash(data),
+        Algorithm::SHA2224 => sha1_2256_2224_2384_2512::sha2224::hash(data),
+        Algorithm::SHA2256 => sha1_2256_2224_2384_2512::sha2256::hash(data),
+        Algorithm::SHA2384 => sha1_2256_2224_2384_2512::sha2384::hash(data),
+        Algorithm::SHA2512 => sha1_2256_2224_2384_2512::sha2512::hash(data),
+        Algorithm::SHA3256 => sha3256_3512::sha3256::hash(data),
+        Algorithm::SHA3512 => sha3256_3512::sha3512::hash(data),
+        Algorithm::BLAKE => blake::hash(data),
+        Algorithm::BLAKE2 => blake2::hash(data),
+        Algorithm::CRC64 => crc32_64::crc64::hash(data),
+        Algorithm::CRC32 => crc32_64::crc32::hash(data),
+        Algorithm::CRC32C => crc32c::hash(data),
+        Algorithm::CRC16 => crc16::hash(data),
+        Algorithm::CRC8 => crc8::hash(data),
+        Algorithm::MD5 => md5::hash(data),
+        Algorithm::MD6128 => md6128_256_512::md6128::hash(data),
+        Algorithm::MD6256 => md6128_256_512::md6256::hash(data),
+        Algorithm::MD6512 => md6128_256_512::md6512::hash(data),
+        Algorithm::XOR8 => xor8::hash(data),
+    }
+}
+
+
+/// Hash the specified byte stream using the specified hashing algorithm.
 pub fn hash_file(path: &Path, algo: Algorithm) -> String {
     let mut file = File::open(path).unwrap();
-    match algo {
-        Algorithm::SHA1 => sha1_2256_2224_2384_2512::sha1::hash(&mut file),
-        Algorithm::SHA2224 => sha1_2256_2224_2384_2512::sha2224::hash(&mut file),
-        Algorithm::SHA2256 => sha1_2256_2224_2384_2512::sha2256::hash(&mut file),
-        Algorithm::SHA2384 => sha1_2256_2224_2384_2512::sha2384::hash(&mut file),
-        Algorithm::SHA2512 => sha1_2256_2224_2384_2512::sha2512::hash(&mut file),
-        Algorithm::SHA3256 => sha3256_3512::sha3256::hash(&mut file),
-        Algorithm::SHA3512 => sha3256_3512::sha3512::hash(&mut file),
-        Algorithm::BLAKE => blake::hash(&mut file),
-        Algorithm::BLAKE2 => blake2::hash(&mut file),
-        Algorithm::CRC64 => crc32_64::crc64::hash(&mut file),
-        Algorithm::CRC32 => crc32_64::crc32::hash(&mut file),
-        Algorithm::CRC32C => crc32c::hash(&mut file),
-        Algorithm::CRC16 => crc16::hash(&mut file),
-        Algorithm::CRC8 => crc8::hash(&mut file),
-        Algorithm::MD5 => md5::hash(&mut file),
-        Algorithm::MD6128 => md6128_256_512::md6128::hash(&mut file),
-        Algorithm::MD6256 => md6128_256_512::md6256::hash(&mut file),
-        Algorithm::MD6512 => md6128_256_512::md6512::hash(&mut file),
-        Algorithm::XOR8 => xor8::hash(&mut file),
-    }
+    hash_reader(&mut file, algo)
 }
 
 /// Create a hash string out of its raw bytes.


### PR DESCRIPTION
allows other crates to take advantage of this crate without passing data into a file first